### PR TITLE
Docs improvements by grouping modules

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Cldr.Mixfile do
     [
       {:poison, "~> 2.1 or ~> 3.0"},
       {:decimal, "~> 1.4"},
-      {:ex_doc, github: "elixir-lang/ex_doc", branch: "master", only: :dev},
+      {:ex_doc, "~> 0.17", only: :dev},
       {:ex_abnf, "~> 0.3.0"},
       {:excoveralls, "~> 0.7.2", only: :test},
       {:gettext, "~> 0.13.0", optional: true},
@@ -115,10 +115,24 @@ defmodule Cldr.Mixfile do
 
   defp groups_for_modules do
     [
-      "Number": ~r/^Cldr.Number.?/,
-      "Normalize": ~r/^Cldr.Normalize.?/,
+      "Config": [
+        Cldr.Config,
+        Cldr.Rbnf.Config
+      ],
+      "Language Tag": ~r/^Cldr.LanguageTag.?/,
+      "Plural Rules": ~r/^Cldr.Number.?/,
+      "Normalization": ~r/^Cldr.Normalize.?/,
       "Gettext": ~r/^Cldr.Gettext.?/,
-      "Helpers": [Cldr.Helpers, Cldr.Map, Cldr.Math]
+      "Helpers": [
+        Cldr.Calendar.Conversion,
+        Cldr.Digits,
+        Cldr.Helpers, 
+        Cldr.Locale.Cache,
+        Cldr.Macros,
+        Cldr.Map, 
+        Cldr.Math, 
+        Cldr.String
+      ]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Cldr.Mixfile do
     [
       {:poison, "~> 2.1 or ~> 3.0"},
       {:decimal, "~> 1.4"},
-      {:ex_doc, "~> 0.15", only: :dev},
+      {:ex_doc, github: "elixir-lang/ex_doc", branch: "master", only: :dev},
       {:ex_abnf, "~> 0.3.0"},
       {:excoveralls, "~> 0.7.2", only: :test},
       {:gettext, "~> 0.13.0", optional: true},
@@ -96,7 +96,8 @@ defmodule Cldr.Mixfile do
       source_ref: "v#{@version}",
       main: "1_getting_started",
       extra_section: "GUIDES",
-      extras: extra_docs()
+      extras: extra_docs(),
+      groups_for_modules: groups_for_modules()
     ]
   end
 
@@ -110,6 +111,15 @@ defmodule Cldr.Mixfile do
     |> File.ls!
     |> Enum.map(&Path.join(@doc_dir, &1))
     |> Enum.sort
+  end
+
+  defp groups_for_modules do
+    [
+      "Number": ~r/^Cldr.Number.?/,
+      "Normalize": ~r/^Cldr.Normalize.?/,
+      "Gettext": ~r/^Cldr.Gettext.?/,
+      "Helpers": [Cldr.Helpers, Cldr.Map, Cldr.Math]
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "mix", "test"]

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.0.6", "9dcbf819c2a77f67a66b83739b7fcc00b71aaf6c100016db4f798930fa4cfd47", [:mix], [{:db_connection, "~> 1.0", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
   "ex_abnf": {:hex, :ex_abnf, "0.3.0", "07847d0d6cb75b779948520d02cba80eb855e18acb1aa8d43b1e370ef31afbcb", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.4", "4bf6b82d4f0a643b500366ed7134896e8cccdbab4d1a7a35524951b25b1ec9f0", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:git, "https://github.com/elixir-lang/ex_doc.git", "d6f03c18d1207f710d76d97e6b19b8914e4ddddd", [branch: "master"]},
   "excoveralls": {:hex, :excoveralls, "0.7.2", "f69ede8c122ccd3b60afc775348a53fc8c39fe4278aee2f538f0d81cc5e7ff3a", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "exprintf": {:hex, :exprintf, "0.2.1", "b7e895dfb00520cfb7fc1671303b63b37dc3897c59be7cbf1ae62f766a8a0314", [:mix], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.0.6", "9dcbf819c2a77f67a66b83739b7fcc00b71aaf6c100016db4f798930fa4cfd47", [:mix], [{:db_connection, "~> 1.0", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
   "ex_abnf": {:hex, :ex_abnf, "0.3.0", "07847d0d6cb75b779948520d02cba80eb855e18acb1aa8d43b1e370ef31afbcb", [], [], "hexpm"},
-  "ex_doc": {:git, "https://github.com/elixir-lang/ex_doc.git", "d6f03c18d1207f710d76d97e6b19b8914e4ddddd", [branch: "master"]},
+  "ex_doc": {:hex, :ex_doc, "0.17.0", "fdf3dc9c6cd1945afb583488de1bf8c12bd8b2ab80f2e7a0e2476a60b9e3bd8f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.7.2", "f69ede8c122ccd3b60afc775348a53fc8c39fe4278aee2f538f0d81cc5e7ff3a", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "exprintf": {:hex, :exprintf, "0.2.1", "b7e895dfb00520cfb7fc1671303b63b37dc3897c59be7cbf1ae62f766a8a0314", [:mix], [], "hexpm"},


### PR DESCRIPTION
I just wanted to create the PRs while I have some free time. Will update it to use ex_doc v0.17 as soon as it's released. I kind of guessed the helper modules by the module docs present by now. Maybe there are more modules you think might be nice to be visually grouped in the documentation as well.