### PR TITLE
Silence unused variable warnings without @compile

### DIFF
--- a/lib/cldr/plural_rules/cardinal.ex
+++ b/lib/cldr/plural_rules/cardinal.ex
@@ -3,8 +3,6 @@ defmodule Cldr.Number.Cardinal do
   Implements cardinal plural rules for numbers.
   """
 
-  @compile :nowarn_unused_vars
-
   use Cldr.Number.PluralRule, :cardinal
   alias Cldr.LanguageTag
 
@@ -30,6 +28,8 @@ defmodule Cldr.Number.Cardinal do
       |> rules_to_condition_statement(__MODULE__)
 
     defp do_plural_rule(%LanguageTag{cldr_locale_name: unquote(locale_name)}, n, i, v, w, f, t) do
+      # silence unused variable warnings
+      _ = {n, i, v, w, f, t}
       unquote(function_body)
     end
   end

--- a/lib/cldr/plural_rules/ordinal.ex
+++ b/lib/cldr/plural_rules/ordinal.ex
@@ -3,8 +3,6 @@ defmodule Cldr.Number.Ordinal do
   Implements ordinal plural rules for numbers.
   """
 
-  @compile :nowarn_unused_vars
-
   use Cldr.Number.PluralRule, :ordinal
   alias Cldr.LanguageTag
 
@@ -30,6 +28,8 @@ defmodule Cldr.Number.Ordinal do
       |> rules_to_condition_statement(__MODULE__)
 
     defp do_plural_rule(%LanguageTag{cldr_locale_name: unquote(locale_name)}, n, i, v, w, f, t) do
+      # silence unused variable warnings
+      _ = {n, i, v, w, f, t}
       unquote(function_body)
     end
   end


### PR DESCRIPTION
The compiler is smart enough to eliminate the tuples, so there's no
runtime cost. I double verified by comparing the emitted assembly, it's
exactly the same.

Addresses elixir-lang/elixir#7293