### PR TITLE
Handle invalid currency in locale param

### DIFF
--- a/lib/cldr/language_tag/parser.ex
+++ b/lib/cldr/language_tag/parser.ex
@@ -228,7 +228,7 @@ defmodule Cldr.LanguageTag.Parser do
   defp canonicalize_key([key, valid, default], param) when is_function(valid) do
     case valid.(param) do
       {:ok, value} -> {key, value}
-      {:error, _} -> default
+      {:error, _} -> {key, default}
     end
   end
 

--- a/test/locale_parser_test.exs
+++ b/test/locale_parser_test.exs
@@ -4,6 +4,22 @@ defmodule CldrLocaleParserTest do
 
   doctest Cldr.LanguageTag.Parser
 
+  @invalid_locale_name "zz"
+  @invalid_territory_code :AA
+  @invalid_currency_code :AAA
+
+  test "That invalid locale name is invalid" do
+    assert @invalid_locale_name not in Cldr.known_locale_names()
+  end
+
+  test "That invalid territory code is invalid" do
+    assert @invalid_territory_code not in Cldr.known_territories()
+  end
+
+  test "That invalid currency code is invalid" do
+    assert @invalid_currency_code not in Cldr.known_currencies()
+  end
+
   @language_codes [
     # "und-Cyrl-t-und-latn-m0-ungegn-2007",
     "en-US-x-twain",
@@ -21,7 +37,10 @@ defmodule CldrLocaleParserTest do
     "und-u-cu-usd",
     "en_US_u_tz_uslax_va_posix",
     "th_TH_u_ca_gregory_nu_thai",
-    "zh_Hant_TW_u_co_big5han"
+    "zh_Hant_TW_u_co_big5han",
+    "#{@invalid_locale_name}-US", # Invalid language
+    "en-#{@invalid_territory_code}", # Invalid country
+    "en-US-u-cu-#{@invalid_currency_code}" # Invalid currency
   ]
 
   for code <- @language_codes do

--- a/test/locale_parser_test.exs
+++ b/test/locale_parser_test.exs
@@ -4,22 +4,6 @@ defmodule CldrLocaleParserTest do
 
   doctest Cldr.LanguageTag.Parser
 
-  @invalid_locale_name "zz"
-  @invalid_territory_code :AA
-  @invalid_currency_code :AAA
-
-  test "That invalid locale name is invalid" do
-    assert @invalid_locale_name not in Cldr.known_locale_names()
-  end
-
-  test "That invalid territory code is invalid" do
-    assert @invalid_territory_code not in Cldr.known_territories()
-  end
-
-  test "That invalid currency code is invalid" do
-    assert @invalid_currency_code not in Cldr.known_currencies()
-  end
-
   @language_codes [
     # "und-Cyrl-t-und-latn-m0-ungegn-2007",
     "en-US-x-twain",
@@ -37,15 +21,54 @@ defmodule CldrLocaleParserTest do
     "und-u-cu-usd",
     "en_US_u_tz_uslax_va_posix",
     "th_TH_u_ca_gregory_nu_thai",
-    "zh_Hant_TW_u_co_big5han",
-    "#{@invalid_locale_name}-US", # Invalid language
-    "en-#{@invalid_territory_code}", # Invalid country
-    "en-US-u-cu-#{@invalid_currency_code}" # Invalid currency
+    "zh_Hant_TW_u_co_big5han"
   ]
 
   for code <- @language_codes do
     test "That #{inspect(code)} parses without error" do
       assert {:ok, _} = Parser.parse(unquote(code))
     end
+  end
+
+  test "That invalid locale string returns error" do
+    assert {:error, _error} = Parser.parse("-invalid")
+  end
+
+  test "That invalid language code is handled" do
+    assert {:ok, language_tag} = Parser.parse("aaaaa")
+    assert is_nil(language_tag.cldr_locale_name)
+    assert language_tag.language == "aaaaa"
+  end
+
+  test "That nonexistent language code is handled" do
+    assert {:ok, language_tag} = Parser.parse("zz")
+    assert is_nil(language_tag.cldr_locale_name)
+    assert language_tag.language == "zz"
+  end
+
+  test "That invalid territory code is handled" do
+    assert {:ok, language_tag} = Parser.parse("en-AAAA")
+    assert language_tag.language == "en"
+    assert is_nil(language_tag.territory)
+  end
+
+  test "That nonexistent territory code is handled" do
+    assert {:ok, language_tag} = Parser.parse("en-AA")
+    assert language_tag.language == "en"
+    assert language_tag.territory == "AA"
+  end
+
+  test "That invalid currency code is handled" do
+    assert {:ok, language_tag} = Parser.parse("en-US-u-cu-AAAAAA")
+    assert language_tag.language == "en"
+    assert language_tag.territory == "US"
+    assert is_nil(language_tag.locale.currency)
+  end
+
+  test "That nonexistent currency code is handled" do
+    assert {:ok, language_tag} = Parser.parse("en-US-u-cu-AAA")
+    assert language_tag.language == "en"
+    assert language_tag.territory == "US"
+    assert is_nil(language_tag.locale.currency)
   end
 end


### PR DESCRIPTION
There's an issue when parsing a locale param with an invalid currency:

```elixir
     ** (ArgumentError) argument error
     code: |> get(Routes.index_path(conn, :index))
     stacktrace:
       (stdlib) :maps.from_list([nil])
       (elixir) lib/map.ex:167: Map.new/1
       (ex_cldr) deps/ex_cldr/lib/cldr/language_tag/parser.ex:159: Cldr.LanguageTag.Parser.canonicalize_locale_keys/1
       (ex_cldr) deps/ex_cldr/lib/cldr/language_tag/parser.ex:35: Cldr.LanguageTag.Parser.parse/1
       (ex_cldr) deps/ex_cldr/lib/cldr/locale.ex:234: Cldr.Locale.canonical_language_tag/1
       (ex_cldr) deps/ex_cldr/lib/cldr.ex:559: Cldr.validate_locale/1
       (ex_cldr) lib/cldr/plug/plug_set_locale.ex:110: anonymous fn/4 in Cldr.Plug.SetLocale.locale_from_params/3
       # ...
```

The issue is in `canonicalize_key/2` where the default value is not returned in a tuple, and thus with an invalid currency is returned as nil. You'll end up with a `[nil]` list, and this can't be passed into a map. I've just changed so it returns a tuple with the default value. It might be good to add more tests with default values.

The invalid language/country/locale code tests are not necessary, but I just wanted to make sure that we're actually testing invalid locale strings. There's probably a better way to ensure we're testing only codes that doesn't exist.