### PR TITLE
Remove cldr_languages from known providers

### DIFF
--- a/lib/cldr/config/dependents.ex
+++ b/lib/cldr/config/dependents.ex
@@ -8,8 +8,7 @@ defmodule Cldr.Config.Dependents do
       Cldr.DateTime  => {Cldr.DateTime.Backend, :define_date_time_modules},
       Cldr.List      => {Cldr.List.Backend, :define_list_module},
       Cldr.Unit      => {Cldr.Unit.Backend, :define_unit_module},
-      Cldr.Territory => {Cldr.Territory.Backend, :define_territory_module},
-      Cldr.Language  => {Cldr.Language.Backend, :define_language_module}
+      Cldr.Territory => {Cldr.Territory.Backend, :define_territory_module}
     }
   end
 


### PR DESCRIPTION
I've implemented v2 with `cldr_backend_provider` callback, contrary to the PR @Schultzer sent, so it doesn't need to be in known providers. By now both options work, but I'd like to get rid of the additional module, which basically just delegates: https://github.com/LostKobrakai/cldr_languages/blob/e1fd9a6bb61803c5c88a0ef2975cf3af4a158126/lib/cldr/language.ex#L31-L38